### PR TITLE
Add CLI, TUI, and Cloudflare API client modules

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Cloudflare DNS CLI — scriptable interface for managing DNS records.
+
+Can be run from any directory:
+    python /path/to/cf-ddns/cli.py zones list
+    python /path/to/cf-ddns/cli.py records list --zone example.com
+    python /path/to/cf-ddns/cli.py records create --zone example.com --type A --name www --content 1.2.3.4
+    python /path/to/cf-ddns/cli.py records update --zone example.com --id <id> --content 5.6.7.8
+    python /path/to/cf-ddns/cli.py records delete --zone example.com --id <id>
+
+Add --json to any command for machine-readable output.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+# Load .env from the directory this script lives in, so it works from anywhere
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)
+
+from dotenv import load_dotenv
+load_dotenv(os.path.join(_HERE, ".env"))
+
+from cloudflare import PRIORITY_TYPES, PROXIABLE_TYPES, CloudflareAPI
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def get_api() -> CloudflareAPI:
+    token = os.getenv("CLOUDFLARE_API_TOKEN")
+    if not token:
+        _die("CLOUDFLARE_API_TOKEN not set in environment or .env")
+    return CloudflareAPI(token)
+
+
+def resolve_zone(api: CloudflareAPI, zone_arg: str) -> dict:
+    """Accept zone name (example.com) or zone ID."""
+    for zone in api.get_zones():
+        if zone["name"] == zone_arg or zone["id"] == zone_arg:
+            return zone
+    _die(f"Zone '{zone_arg}' not found")
+
+
+def _die(msg: str) -> None:
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _print_table(rows: list[dict], fields: list[str]) -> None:
+    if not rows:
+        print("(no results)")
+        return
+    widths = {f: len(f) for f in fields}
+    for row in rows:
+        for f in fields:
+            widths[f] = max(widths[f], len(str(row.get(f, ""))))
+    header = "  ".join(f.upper().ljust(widths[f]) for f in fields)
+    print(header)
+    print("  ".join("-" * widths[f] for f in fields))
+    for row in rows:
+        print("  ".join(str(row.get(f, "")).ljust(widths[f]) for f in fields))
+
+
+def _out(data, as_json: bool, fields: list[str] | None = None) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2))
+    elif isinstance(data, list):
+        _print_table(data, fields or (list(data[0].keys()) if data else []))
+    else:
+        for k, v in data.items():
+            print(f"{k}: {v}")
+
+
+def _ttl_display(ttl) -> str:
+    return "Auto" if ttl == 1 else str(ttl)
+
+
+def _format_zones(zones: list[dict]) -> list[dict]:
+    return [{"name": z["name"], "id": z["id"], "status": z.get("status", "")} for z in zones]
+
+
+def _format_records(records: list[dict]) -> list[dict]:
+    out = []
+    for r in records:
+        out.append({
+            "id": r["id"],
+            "name": r["name"],
+            "type": r["type"],
+            "content": r["content"],
+            "ttl": _ttl_display(r.get("ttl", 1)),
+            "proxied": str(r.get("proxied", "")).lower() if r.get("proxiable") else "—",
+            "priority": str(r["priority"]) if "priority" in r else "",
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Command handlers
+# ---------------------------------------------------------------------------
+
+def cmd_zones_list(args) -> None:
+    api = get_api()
+    zones = api.get_zones()
+    if args.json:
+        _out(zones, True)
+    else:
+        _out(_format_zones(zones), False, ["name", "id", "status"])
+
+
+def cmd_records_list(args) -> None:
+    api = get_api()
+    zone = resolve_zone(api, args.zone)
+    records = api.get_dns_records(zone["id"])
+    if args.type:
+        records = [r for r in records if r["type"].upper() == args.type.upper()]
+    if args.json:
+        _out(records, True)
+    else:
+        fields = ["id", "name", "type", "content", "ttl", "proxied"]
+        _out(_format_records(records), False, fields)
+
+
+def cmd_records_get(args) -> None:
+    api = get_api()
+    zone = resolve_zone(api, args.zone)
+    records = api.get_dns_records(zone["id"])
+    match = next((r for r in records if r["id"] == args.id), None)
+    if not match:
+        _die(f"Record '{args.id}' not found in zone '{args.zone}'")
+    _out(match if args.json else _format_records([match])[0], args.json)
+
+
+def cmd_records_create(args) -> None:
+    api = get_api()
+    zone = resolve_zone(api, args.zone)
+    data: dict = {
+        "type": args.type.upper(),
+        "name": args.name,
+        "content": args.content,
+        "ttl": args.ttl,
+    }
+    if args.type.upper() in PROXIABLE_TYPES:
+        data["proxied"] = args.proxied
+    if args.type.upper() in PRIORITY_TYPES:
+        if args.priority is None:
+            _die(f"--priority is required for {args.type} records")
+        data["priority"] = args.priority
+    result = api.create_dns_record(zone["id"], data)
+    _out(result if args.json else _format_records([result])[0], args.json)
+
+
+def cmd_records_update(args) -> None:
+    api = get_api()
+    zone = resolve_zone(api, args.zone)
+    # Fetch current record so we only override what was provided
+    records = api.get_dns_records(zone["id"])
+    current = next((r for r in records if r["id"] == args.id), None)
+    if not current:
+        _die(f"Record '{args.id}' not found in zone '{args.zone}'")
+    data: dict = {
+        "type": (args.type or current["type"]).upper(),
+        "name": args.name or current["name"],
+        "content": args.content or current["content"],
+        "ttl": args.ttl if args.ttl is not None else current.get("ttl", 1),
+    }
+    rec_type = data["type"]
+    if rec_type in PROXIABLE_TYPES:
+        data["proxied"] = args.proxied if args.proxied is not None else current.get("proxied", False)
+    if rec_type in PRIORITY_TYPES:
+        data["priority"] = args.priority if args.priority is not None else current.get("priority", 10)
+    result = api.update_dns_record(zone["id"], args.id, data)
+    _out(result if args.json else _format_records([result])[0], args.json)
+
+
+def cmd_records_delete(args) -> None:
+    api = get_api()
+    zone = resolve_zone(api, args.zone)
+    result = api.delete_dns_record(zone["id"], args.id)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"deleted: {args.id}")
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    # Shared --json flag inherited by every subcommand
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--json", action="store_true", help="Output raw JSON")
+
+    parser = argparse.ArgumentParser(
+        prog="cli.py",
+        description="Cloudflare DNS manager — scriptable CLI",
+    )
+    sub = parser.add_subparsers(dest="resource", metavar="<resource>", required=True)
+
+    # -- zones ----------------------------------------------------------------
+    zones_p = sub.add_parser("zones", help="Manage zones")
+    zones_sub = zones_p.add_subparsers(dest="action", metavar="<action>", required=True)
+
+    zones_list = zones_sub.add_parser("list", help="List all zones", parents=[common])
+    zones_list.set_defaults(func=cmd_zones_list)
+
+    # -- records --------------------------------------------------------------
+    records_p = sub.add_parser("records", help="Manage DNS records")
+    records_sub = records_p.add_subparsers(dest="action", metavar="<action>", required=True)
+
+    # records list
+    rl = records_sub.add_parser("list", help="List records for a zone", parents=[common])
+    rl.add_argument("--zone", required=True, metavar="NAME_OR_ID")
+    rl.add_argument("--type", metavar="TYPE", help="Filter by record type (A, CNAME, MX, ...)")
+    rl.set_defaults(func=cmd_records_list)
+
+    # records get
+    rg = records_sub.add_parser("get", help="Get a single record by ID", parents=[common])
+    rg.add_argument("--zone", required=True, metavar="NAME_OR_ID")
+    rg.add_argument("--id", required=True, metavar="RECORD_ID")
+    rg.set_defaults(func=cmd_records_get)
+
+    # records create
+    rc = records_sub.add_parser("create", help="Create a new DNS record", parents=[common])
+    rc.add_argument("--zone", required=True, metavar="NAME_OR_ID")
+    rc.add_argument("--type", required=True, metavar="TYPE")
+    rc.add_argument("--name", required=True, metavar="NAME", help="Subdomain or @ for root")
+    rc.add_argument("--content", required=True, metavar="VALUE")
+    rc.add_argument("--ttl", type=int, default=1, metavar="SECONDS", help="TTL (1 = Auto)")
+    rc.add_argument("--proxied", action="store_true", default=False)
+    rc.add_argument("--priority", type=int, metavar="N", help="Required for MX/SRV")
+    rc.set_defaults(func=cmd_records_create)
+
+    # records update
+    ru = records_sub.add_parser("update", help="Update an existing DNS record", parents=[common])
+    ru.add_argument("--zone", required=True, metavar="NAME_OR_ID")
+    ru.add_argument("--id", required=True, metavar="RECORD_ID")
+    ru.add_argument("--type", metavar="TYPE")
+    ru.add_argument("--name", metavar="NAME")
+    ru.add_argument("--content", metavar="VALUE")
+    ru.add_argument("--ttl", type=int, metavar="SECONDS")
+    ru.add_argument("--proxied", action=argparse.BooleanOptionalAction, default=None)
+    ru.add_argument("--priority", type=int, metavar="N")
+    ru.set_defaults(func=cmd_records_update)
+
+    # records delete
+    rd = records_sub.add_parser("delete", help="Delete a DNS record", parents=[common])
+    rd.add_argument("--zone", required=True, metavar="NAME_OR_ID")
+    rd.add_argument("--id", required=True, metavar="RECORD_ID")
+    rd.set_defaults(func=cmd_records_delete)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/cloudflare.py
+++ b/cloudflare.py
@@ -1,0 +1,46 @@
+"""Cloudflare API client for DNS record management."""
+
+import requests
+
+CF_API_BASE = "https://api.cloudflare.com/client/v4"
+
+PROXIABLE_TYPES = {"A", "AAAA", "CNAME"}
+PRIORITY_TYPES = {"MX", "SRV", "URI"}
+
+
+class CloudflareAPI:
+    def __init__(self, token: str):
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        r = requests.request(
+            method, f"{CF_API_BASE}{path}", headers=self.headers, timeout=10, **kwargs
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def get_zones(self) -> list[dict]:
+        return self._request("GET", "/zones", params={"per_page": 100}).get("result", [])
+
+    def get_dns_records(self, zone_id: str) -> list[dict]:
+        return self._request(
+            "GET", f"/zones/{zone_id}/dns_records", params={"per_page": 500}
+        ).get("result", [])
+
+    def create_dns_record(self, zone_id: str, data: dict) -> dict:
+        return self._request(
+            "POST", f"/zones/{zone_id}/dns_records", json=data
+        ).get("result", {})
+
+    def update_dns_record(self, zone_id: str, record_id: str, data: dict) -> dict:
+        return self._request(
+            "PUT", f"/zones/{zone_id}/dns_records/{record_id}", json=data
+        ).get("result", {})
+
+    def delete_dns_record(self, zone_id: str, record_id: str) -> dict:
+        return self._request(
+            "DELETE", f"/zones/{zone_id}/dns_records/{record_id}"
+        ).get("result", {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 certifi==2024.2.2
+textual>=0.60.0
 charset-normalizer==3.3.2
 idna==3.6
 iniconfig==2.0.0

--- a/tui.py
+++ b/tui.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""Cloudflare DNS Manager — interactive TUI for viewing and managing DNS records."""
+
+import os
+import sys
+
+from dotenv import load_dotenv
+from textual import on, work
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, DataTable, Footer, Header, Input, Label, Select, Switch
+
+from cloudflare import PRIORITY_TYPES, PROXIABLE_TYPES, CloudflareAPI
+
+RECORD_TYPES = [
+    "A", "AAAA", "CNAME", "MX", "TXT", "NS", "CAA", "SRV", "PTR", "HTTPS", "TLSA", "DS",
+]
+
+
+class RecordFormModal(ModalScreen):
+    """Create or edit a DNS record."""
+
+    DEFAULT_CSS = """
+    RecordFormModal {
+        align: center middle;
+    }
+    #form-dialog {
+        background: $surface;
+        border: thick $primary;
+        padding: 1 3;
+        width: 74;
+        height: auto;
+    }
+    #form-title {
+        text-align: center;
+        text-style: bold;
+        color: $accent;
+        padding-bottom: 1;
+    }
+    .field-row {
+        height: 3;
+        align: left middle;
+    }
+    .field-label {
+        width: 12;
+        text-align: right;
+        padding-right: 1;
+        padding-top: 1;
+        color: $text-muted;
+    }
+    .field-row Input, .field-row Select {
+        width: 1fr;
+    }
+    #button-row {
+        margin-top: 1;
+        align: center middle;
+        height: 3;
+    }
+    #button-row Button {
+        margin: 0 1;
+    }
+    """
+
+    def __init__(self, zone_name: str, record: dict | None = None):
+        super().__init__()
+        self.zone_name = zone_name
+        self.record = record
+
+    def compose(self) -> ComposeResult:
+        title = f"{'Edit' if self.record else 'New'} Record — {self.zone_name}"
+        # Ensure the record's type is in our list
+        initial_type = (self.record["type"] if self.record else "A") or "A"
+        type_options = RECORD_TYPES if initial_type in RECORD_TYPES else [initial_type, *RECORD_TYPES]
+
+        with Vertical(id="form-dialog"):
+            yield Label(title, id="form-title")
+            with Horizontal(classes="field-row"):
+                yield Label("Type:", classes="field-label")
+                yield Select(
+                    [(t, t) for t in type_options],
+                    id="field-type",
+                    value=initial_type,
+                    allow_blank=False,
+                )
+            with Horizontal(classes="field-row"):
+                yield Label("Name:", classes="field-label")
+                yield Input(
+                    value=self.record["name"] if self.record else "",
+                    placeholder="@ or subdomain",
+                    id="field-name",
+                )
+            with Horizontal(classes="field-row"):
+                yield Label("Content:", classes="field-label")
+                yield Input(
+                    value=self.record["content"] if self.record else "",
+                    placeholder="IP address, hostname, or value",
+                    id="field-content",
+                )
+            with Horizontal(classes="field-row", id="priority-row"):
+                yield Label("Priority:", classes="field-label")
+                priority_val = str(self.record.get("priority", 10)) if self.record else "10"
+                yield Input(value=priority_val, placeholder="e.g. 10", id="field-priority")
+            with Horizontal(classes="field-row"):
+                yield Label("TTL:", classes="field-label")
+                ttl_val = str(self.record.get("ttl", 1)) if self.record else "1"
+                yield Input(value=ttl_val, placeholder="1 = Auto", id="field-ttl")
+            with Horizontal(classes="field-row", id="proxied-row"):
+                yield Label("Proxied:", classes="field-label")
+                proxied_val = self.record.get("proxied", False) if self.record else False
+                yield Switch(value=proxied_val, id="field-proxied")
+            with Horizontal(id="button-row"):
+                yield Button("Save", variant="primary", id="btn-save")
+                yield Button("Cancel", id="btn-cancel")
+
+    def on_mount(self) -> None:
+        self._update_field_visibility()
+        self.query_one("#field-name", Input).focus()
+
+    def _update_field_visibility(self) -> None:
+        rec_type = self.query_one("#field-type", Select).value
+        if rec_type is Select.NULL:
+            return
+        self.query_one("#priority-row").display = rec_type in PRIORITY_TYPES
+        self.query_one("#proxied-row").display = rec_type in PROXIABLE_TYPES
+
+    @on(Select.Changed, "#field-type")
+    def on_type_changed(self, event: Select.Changed) -> None:
+        self._update_field_visibility()
+
+    @on(Button.Pressed, "#btn-cancel")
+    def on_cancel(self) -> None:
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#btn-save")
+    def on_save(self) -> None:
+        rec_type = self.query_one("#field-type", Select).value
+        if rec_type is Select.NULL:
+            self.notify("Please select a record type", severity="warning")
+            return
+
+        name = self.query_one("#field-name", Input).value.strip()
+        content = self.query_one("#field-content", Input).value.strip()
+        ttl_str = self.query_one("#field-ttl", Input).value.strip() or "1"
+
+        if not name or not content:
+            self.notify("Name and content are required", severity="warning")
+            return
+
+        try:
+            ttl = int(ttl_str)
+        except ValueError:
+            self.notify("TTL must be a number (1 = Auto)", severity="warning")
+            return
+
+        data: dict = {"type": rec_type, "name": name, "content": content, "ttl": ttl}
+
+        if rec_type in PROXIABLE_TYPES:
+            data["proxied"] = self.query_one("#field-proxied", Switch).value
+
+        if rec_type in PRIORITY_TYPES:
+            priority_str = self.query_one("#field-priority", Input).value.strip() or "10"
+            try:
+                data["priority"] = int(priority_str)
+            except ValueError:
+                self.notify("Priority must be a number", severity="warning")
+                return
+
+        result: dict = {"data": data}
+        if self.record:
+            result["id"] = self.record["id"]
+        self.dismiss(result)
+
+
+class ConfirmModal(ModalScreen):
+    """Confirmation dialog for destructive actions."""
+
+    DEFAULT_CSS = """
+    ConfirmModal {
+        align: center middle;
+    }
+    #confirm-dialog {
+        background: $surface;
+        border: thick $error;
+        padding: 2 4;
+        width: 54;
+        height: auto;
+    }
+    #confirm-message {
+        text-align: center;
+        padding-bottom: 2;
+    }
+    #confirm-buttons {
+        align: center middle;
+        height: 3;
+    }
+    #confirm-buttons Button {
+        margin: 0 1;
+    }
+    """
+
+    def __init__(self, message: str):
+        super().__init__()
+        self.message = message
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-dialog"):
+            yield Label(self.message, id="confirm-message")
+            with Horizontal(id="confirm-buttons"):
+                yield Button("Delete", variant="error", id="btn-confirm")
+                yield Button("Cancel", id="btn-cancel")
+
+    @on(Button.Pressed, "#btn-confirm")
+    def on_confirm(self) -> None:
+        self.dismiss(True)
+
+    @on(Button.Pressed, "#btn-cancel")
+    def on_cancel(self) -> None:
+        self.dismiss(False)
+
+
+class DNSManagerApp(App):
+    """Cloudflare DNS Manager TUI."""
+
+    TITLE = "CF DNS Manager"
+
+    DEFAULT_CSS = """
+    Screen {
+        background: $background;
+    }
+    #main {
+        height: 1fr;
+        padding: 1;
+    }
+    #zones-panel {
+        width: 34;
+        border: round $primary;
+        margin-right: 1;
+    }
+    #records-panel {
+        width: 1fr;
+        border: round $primary;
+    }
+    .panel-title {
+        background: $primary;
+        color: $text;
+        padding: 0 1;
+        width: 100%;
+        text-align: center;
+        text-style: bold;
+    }
+    #zones-table {
+        height: 1fr;
+    }
+    #records-table {
+        height: 1fr;
+    }
+    """
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("n", "new_record", "New"),
+        Binding("e", "edit_record", "Edit"),
+        Binding("d", "delete_record", "Delete"),
+        Binding("escape", "focus_zones", "Zones", show=False),
+        Binding("left", "focus_zones", "Zones", show=False),
+    ]
+
+    def __init__(self, api: CloudflareAPI):
+        super().__init__()
+        self.api = api
+        self.zones: list[dict] = []
+        self.records: list[dict] = []
+        self.selected_zone: dict | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Horizontal(id="main"):
+            with Vertical(id="zones-panel"):
+                yield Label("Zones", classes="panel-title")
+                yield DataTable(id="zones-table", cursor_type="row", zebra_stripes=True)
+            with Vertical(id="records-panel"):
+                yield Label("DNS Records", id="records-title", classes="panel-title")
+                yield DataTable(id="records-table", cursor_type="row", zebra_stripes=True)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        zones_table = self.query_one("#zones-table", DataTable)
+        zones_table.add_column("Zone Name", key="name")
+
+        records_table = self.query_one("#records-table", DataTable)
+        records_table.add_column("Name", key="name")
+        records_table.add_column("Type", key="type")
+        records_table.add_column("Content", key="content")
+        records_table.add_column("TTL", key="ttl")
+        records_table.add_column("Prx", key="proxied")
+
+        self.load_zones()
+
+    @work(exclusive=True, thread=True)
+    def load_zones(self) -> None:
+        try:
+            zones = self.api.get_zones()
+            self.call_from_thread(self._populate_zones, zones)
+        except Exception as e:
+            self.call_from_thread(self.notify, f"Failed to load zones: {e}", severity="error")
+
+    def _populate_zones(self, zones: list[dict]) -> None:
+        self.zones = zones
+        table = self.query_one("#zones-table", DataTable)
+        table.clear()
+        for zone in zones:
+            table.add_row(zone["name"], key=zone["id"])
+        if zones:
+            self.selected_zone = zones[0]
+            self.load_records(zones[0]["id"])
+
+    @work(exclusive=True, thread=True)
+    def load_records(self, zone_id: str) -> None:
+        try:
+            records = self.api.get_dns_records(zone_id)
+            self.call_from_thread(self._populate_records, records)
+        except Exception as e:
+            self.call_from_thread(self.notify, f"Failed to load records: {e}", severity="error")
+
+    def _populate_records(self, records: list[dict]) -> None:
+        self.records = records
+        table = self.query_one("#records-table", DataTable)
+        table.clear()
+        for record in records:
+            ttl_val = "Auto" if record.get("ttl") == 1 else str(record.get("ttl", ""))
+            if record.get("proxiable"):
+                proxied_val = "✓" if record.get("proxied") else "✗"
+            else:
+                proxied_val = "—"
+            table.add_row(
+                record["name"],
+                record["type"],
+                record["content"],
+                ttl_val,
+                proxied_val,
+                key=record["id"],
+            )
+        zone_name = self.selected_zone["name"] if self.selected_zone else ""
+        self.query_one("#records-title", Label).update(f"DNS Records — {zone_name}")
+
+    @on(DataTable.RowHighlighted, "#zones-table")
+    def on_zone_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        idx = event.cursor_row
+        if 0 <= idx < len(self.zones):
+            zone = self.zones[idx]
+            if self.selected_zone is None or self.selected_zone["id"] != zone["id"]:
+                self.selected_zone = zone
+                self.load_records(zone["id"])
+
+    @on(DataTable.RowSelected, "#zones-table")
+    def on_zone_selected(self) -> None:
+        self.query_one("#records-table", DataTable).focus()
+
+    def _selected_record(self) -> dict | None:
+        table = self.query_one("#records-table", DataTable)
+        if not self.records or table.row_count == 0:
+            return None
+        idx = table.cursor_row
+        return self.records[idx] if 0 <= idx < len(self.records) else None
+
+    def action_focus_zones(self) -> None:
+        self.query_one("#zones-table", DataTable).focus()
+
+    def action_refresh(self) -> None:
+        self.load_zones()
+
+    def action_new_record(self) -> None:
+        if not self.selected_zone:
+            self.notify("Select a zone first", severity="warning")
+            return
+        self.push_screen(RecordFormModal(self.selected_zone["name"]), self._on_form_result)
+
+    def action_edit_record(self) -> None:
+        record = self._selected_record()
+        if not record or not self.selected_zone:
+            self.notify("Select a record to edit", severity="warning")
+            return
+        self.push_screen(
+            RecordFormModal(self.selected_zone["name"], record=record),
+            self._on_form_result,
+        )
+
+    def action_delete_record(self) -> None:
+        record = self._selected_record()
+        if not record or not self.selected_zone:
+            self.notify("Select a record to delete", severity="warning")
+            return
+        msg = f"Delete '{record['name']}' ({record['type']})?\n\nThis cannot be undone."
+        self.push_screen(
+            ConfirmModal(msg),
+            lambda confirmed: self._on_delete_confirmed(confirmed, record),
+        )
+
+    def _on_form_result(self, result: dict | None) -> None:
+        if not result or not self.selected_zone:
+            return
+        zone_id = self.selected_zone["id"]
+        if "id" in result:
+            self._update_record(zone_id, result["id"], result["data"])
+        else:
+            self._create_record(zone_id, result["data"])
+
+    def _on_delete_confirmed(self, confirmed: bool | None, record: dict) -> None:
+        if confirmed and self.selected_zone:
+            self._delete_record(self.selected_zone["id"], record["id"])
+
+    @work(thread=True)
+    def _create_record(self, zone_id: str, data: dict) -> None:
+        try:
+            self.api.create_dns_record(zone_id, data)
+            self.call_from_thread(self.notify, "Record created")
+            self.call_from_thread(self.load_records, zone_id)
+        except Exception as e:
+            self.call_from_thread(self.notify, f"Failed to create record: {e}", severity="error")
+
+    @work(thread=True)
+    def _update_record(self, zone_id: str, record_id: str, data: dict) -> None:
+        try:
+            self.api.update_dns_record(zone_id, record_id, data)
+            self.call_from_thread(self.notify, "Record updated")
+            self.call_from_thread(self.load_records, zone_id)
+        except Exception as e:
+            self.call_from_thread(self.notify, f"Failed to update record: {e}", severity="error")
+
+    @work(thread=True)
+    def _delete_record(self, zone_id: str, record_id: str) -> None:
+        try:
+            self.api.delete_dns_record(zone_id, record_id)
+            self.call_from_thread(self.notify, "Record deleted")
+            self.call_from_thread(self.load_records, zone_id)
+        except Exception as e:
+            self.call_from_thread(self.notify, f"Failed to delete record: {e}", severity="error")
+
+
+def main():
+    load_dotenv()
+    token = os.getenv("CLOUDFLARE_API_TOKEN")
+    if not token:
+        print(
+            "Error: CLOUDFLARE_API_TOKEN not set in environment or .env file",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    DNSManagerApp(CloudflareAPI(token)).run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `cli.py`: scriptable command-line interface for managing Cloudflare DNS records
- Adds `tui.py`: interactive terminal UI for viewing and managing DNS records
- Adds `cloudflare.py`: Cloudflare API client library
- Updates `requirements.txt` to include `textual>=0.60.0` for the TUI

## Test plan
- [ ] Run `python cli.py zones list` and verify it returns zones
- [ ] Run `python tui.py` and verify the interactive UI launches
- [ ] Confirm `cloudflare.py` API client functions work correctly against the Cloudflare API

🤖 Generated with [Claude Code](https://claude.com/claude-code)